### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Test mongo-style queries on arbitrary python objects
 
 [![Build Status](https://travis-ci.org/twneale/uni.svg?branch=master)](https://travis-ci.org/twneale/uni)
 [![Coverage Status](https://coveralls.io/repos/twneale/uni/badge.png?branch=master)](https://coveralls.io/r/twneale/uni?branch=master)
-[![Latest Version](https://pypip.in/version/uni/badge.png)](https://pypi.python.org/pypi/uni/)
-[![Download Format](https://pypip.in/format/uni/badge.png)](https://pypi.python.org/pypi/uni/)
+[![Latest Version](https://img.shields.io/pypi/v/uni.svg)](https://pypi.python.org/pypi/uni/)
+[![Download Format](https://img.shields.io/pypi/format/uni.svg)](https://pypi.python.org/pypi/uni/)
 
     import uni
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20uni))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `uni`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.